### PR TITLE
copyright is now dynamic>

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
   <div class="last">
     <p>
       Designed & Developed by Tejas Gupta<br /><a
-        href="https://github.com/multiverseweb/CodeIt/blob/main/LICENSE">&copy; 2024 Tejas Gupta</a>
+        href="https://github.com/multiverseweb/CodeIt/blob/main/LICENSE">&copy; <span id="copyright">2000</span> Tejas Gupta</a>
     </p>
     <div class="links">
       <button class="footer_logo" onclick="copylink()" id="link">
@@ -333,6 +333,9 @@
       chatbotId="pevr_-Kc8RpvaFvi07iVN"
       domain="www.chatbase.co"
       defer>
+      </script>
+      <script>
+        document.getElementById("copyright").textContent = new Date().getFullYear();
       </script>
 </body>
 


### PR DESCRIPTION
Resolves #96 

### Description
I have made the copyright year dynamic. Now even if we hardcode the copyright year in html, it will only show the current year in both the footer section of the Home page as well as the License page


I changed my system's date to year 2025 and that too is getting reflected dynamically 👍 
<img width="460" alt="Screenshot 2025-10-16 at 9 58 53 PM" src="https://github.com/user-attachments/assets/f59719f2-9035-4a6e-8f71-4a7d72d5631d">

