### PR TITLE
CSS Style for #output_code Textarea

### DIFF
--- a/pages/refine.html
+++ b/pages/refine.html
@@ -127,7 +127,11 @@
           <option value="SQL">SQL</option>
           <option value="JavaScript">JavaScript</option>
           <option value="C">C</option>
-          <option value="Java">Java</option>
+          <option value="C#">C#</option>
+          <option value="Typescript">TypeScript</option>
+          <option value="PHP">PHP</option>
+          <option value="Go">Go</option>
+
         </select>
       </form>
       <div class="buttons">

--- a/resources/style.css
+++ b/resources/style.css
@@ -303,14 +303,19 @@ select {
 }
 
 #output_code {
-  color: rgba(0, 255, 204, 0.619);
+  color: rgba(0, 255, 204, 0.619) ! important;
   resize: none;
+  font-family: "Sometype Mono", monospace; 
 }
-
-textarea {
-  font-family: "Sometype Mono", monospace;
+textarea:not(#output_code) {
   color: rgba(255, 255, 255, 0.866);
 }
+
+
+/* textarea {
+  font-family: "Sometype Mono", monospace;
+  color: rgba(255, 255, 255, 0.866);
+} */
 
 input:focus {
   outline: none;


### PR DESCRIPTION
**Issue Title**: CSS Style for #output_code Textarea Not Being Applied Correctly

**Description:** The color style applied to the #output_code textarea element is not being rendered correctly. Despite specifying a unique color for the #output_code element in the CSS, it displays as black in dark mode and blue in light mode.

**Expected Behavior:** The #output_code element should display text in the specified color of rgba(0, 255, 204, 0.619).

**Actual Behavior**: The color for #output_code is displaying as black in dark mode and blue in light mode, indicating that the specified CSS color rule is being overridden or not applied correctly.
 #252 issue Number  under gssoc extend
